### PR TITLE
feat: 스터디 참여 관리 API 구현

### DIFF
--- a/src/main/java/com/example/swip/api/JoinRequestApiController.java
+++ b/src/main/java/com/example/swip/api/JoinRequestApiController.java
@@ -1,0 +1,132 @@
+package com.example.swip.api;
+
+import com.example.swip.config.UserPrincipal;
+import com.example.swip.dto.JoinRequest.JoinRequestResponse;
+import com.example.swip.entity.JoinRequest;
+import com.example.swip.entity.enumtype.JoinStatus;
+import com.example.swip.service.JoinRequestService;
+import com.example.swip.service.UserStudyService;
+import com.querydsl.core.Tuple;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class JoinRequestApiController {
+    private final JoinRequestService joinRequestService;
+    private final UserStudyService userStudyService;
+
+    @Operation(summary = "스터디 신청 내역 조회 (방장용)")
+    @GetMapping("/joinRequest/{study_id}")
+    public ResponseEntity<Result> getJoinRequestsByStudyId(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable("study_id") Long studyId
+            )
+    {
+        if(userPrincipal == null){
+            return ResponseEntity.status(403).body(new Result<>(null, "로그인이 필요합니다."));
+        }
+        Long ownerId = userPrincipal.getUserId();
+        Long findStudyOwner = userStudyService.getOwnerbyStudyId(studyId);
+
+        //방장이면 확인 가능하도록
+        if(ownerId.equals(findStudyOwner)){
+            List<JoinRequest> findJoinRequests= joinRequestService.getAllByStudyId(studyId);
+            //dto 변환 & return
+            List<JoinRequestResponse> responses = findJoinRequests.stream()
+                    .map(request -> {
+                        return JoinRequestResponse.builder()
+                                .study_id(request.getId().getStudyId())
+                                .user_id(request.getId().getUserId())
+                                .join_status(request.getJoin_status().toString())
+                                .request_date(request.getRequest_date())
+                                .nickname(request.getUser().getNickname())
+                                .profile_image(request.getUser().getProfile_image())
+                                .build();
+                    }).collect(Collectors.toList());
+            return ResponseEntity.status(200).body(new Result(responses, "성공"));
+        }
+        return ResponseEntity.status(401).body(new Result(null, "방장이 아닙니다."));
+    }
+
+    @Operation(summary = "스터디 승인 대기중 인원수 조회(방장용)")
+    @GetMapping("/joinRequest/count/{study_id}")
+    public ResponseEntity<Result> getJoinRequestCountByStudyId(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable("study_id") Long studyId
+    ){
+        Long ownerId = userPrincipal.getUserId();
+        Long findStudyOwner = userStudyService.getOwnerbyStudyId(studyId);
+        //방장이면 확인 가능하도록
+        if(userPrincipal == null){
+            return ResponseEntity.status(403).body(new Result(null,"로그인이 필요합니다."));
+        }
+        if(ownerId.equals(findStudyOwner)){
+            Integer size = joinRequestService.getAllWaitingCountByStudyId(studyId);
+            return ResponseEntity.status(200).body(new Result(size, "성공"));
+        }
+        return ResponseEntity.status(401).body(new Result(null, "방장이 아닙니다."));
+    }
+
+    @Operation(summary = "신청 수락 (방장용)")
+    @PostMapping("/joinRequest/accept")
+    private ResponseEntity<String> acceptJoinRequest(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam Long studyId,
+            @RequestParam Long userId
+    )
+    {
+        if(userPrincipal == null){
+            return ResponseEntity.status(403).body("로그인이 필요합니다.");
+        }
+        Long ownerId = userPrincipal.getUserId();
+        Long findStudyOwner = userStudyService.getOwnerbyStudyId(studyId);
+        if(!ownerId.equals(findStudyOwner)) {
+            return ResponseEntity.status(401).body("방장이 아닙니다.");
+        }
+        else {
+            joinRequestService.acceptJoinRequest(studyId, userId);
+            return ResponseEntity.status(200).body("신청 수락 성공");
+        }
+    }
+
+    @Operation(summary = "신청 거부 (방장용)")
+    @PostMapping("/joinRequest/reject")
+    private ResponseEntity<String> rejectJoinRequest(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam Long studyId,
+            @RequestParam Long userId
+    )
+    {
+        if(userPrincipal == null){
+            return ResponseEntity.status(403).body("로그인이 필요합니다.");
+        }
+        Long ownerId = userPrincipal.getUserId();
+        Long findStudyOwner = userStudyService.getOwnerbyStudyId(studyId);
+        if(!ownerId.equals(findStudyOwner)) {
+            return ResponseEntity.status(401).body("방장이 아닙니다.");
+        }
+        else {
+            joinRequestService.rejectJoinRequest(studyId, userId);
+            return ResponseEntity.status(200).body("신청 거부 성공");
+        }
+    }
+
+    // List 값을 Result로 한 번 감싸서 return하기 위한 class
+    @Data
+    @AllArgsConstructor
+    public static class Result<T>{
+        private T data;
+        private String message;
+    }
+
+}

--- a/src/main/java/com/example/swip/dto/JoinRequest/JoinRequestResponse.java
+++ b/src/main/java/com/example/swip/dto/JoinRequest/JoinRequestResponse.java
@@ -1,0 +1,18 @@
+package com.example.swip.dto.JoinRequest;
+
+import com.example.swip.entity.enumtype.JoinStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class JoinRequestResponse {
+    private Long study_id;
+    private Long user_id;
+    private LocalDateTime request_date;
+    private String join_status;
+    private String nickname;
+    private String profile_image;
+}

--- a/src/main/java/com/example/swip/entity/JoinRequest.java
+++ b/src/main/java/com/example/swip/entity/JoinRequest.java
@@ -29,5 +29,7 @@ public class JoinRequest {
     private LocalDateTime request_date;
     private JoinStatus join_status; //대기중:Waiting, 승인됨:Approved 거절됨:Rejected, 취소:Canceled
 
-
+    public void updateJoinStatus(JoinStatus join_status){
+        this.join_status = join_status;
+    }
 }

--- a/src/main/java/com/example/swip/repository/JoinRequestRepository.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepository.java
@@ -4,5 +4,5 @@ import com.example.swip.entity.JoinRequest;
 import com.example.swip.entity.compositeKey.JoinRequestId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JoinRequestRepository extends JpaRepository<JoinRequest, JoinRequestId> {
+public interface JoinRequestRepository extends JpaRepository<JoinRequest, JoinRequestId>, JoinRequestRepositoryCustom {
 }

--- a/src/main/java/com/example/swip/repository/JoinRequestRepositoryCustom.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.swip.repository;
+
+import com.example.swip.entity.JoinRequest;
+
+import java.util.List;
+
+public interface JoinRequestRepositoryCustom {
+    List<JoinRequest> findAllByStudyId(Long studyId);
+
+    List<JoinRequest> findAllWaitingByStudyId(Long studyId);
+}

--- a/src/main/java/com/example/swip/repository/JoinRequestRepositoryImpl.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.example.swip.repository;
+
+import com.example.swip.entity.JoinRequest;
+import com.example.swip.entity.enumtype.JoinStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.example.swip.entity.QJoinRequest.joinRequest;
+import static com.example.swip.entity.QUser.user;
+
+public class JoinRequestRepositoryImpl implements JoinRequestRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    public JoinRequestRepositoryImpl(EntityManager em){
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<JoinRequest> findAllByStudyId(Long studyId) {
+        List<JoinRequest> fetch = queryFactory
+                .select(joinRequest)
+                .from(joinRequest)
+                .leftJoin(joinRequest.user, user)
+                .fetchJoin()
+                .where(joinRequest.id.studyId.eq(studyId))
+                .fetch();
+        return fetch;
+    }
+
+    @Override
+    public List<JoinRequest> findAllWaitingByStudyId(Long studyId) {
+        List<JoinRequest> fetch = queryFactory
+                .select(joinRequest)
+                .from(joinRequest)
+                .leftJoin(joinRequest.user, user)
+                .fetchJoin()
+                .where(
+                        joinRequest.id.studyId.eq(studyId),
+                        joinRequest.join_status.eq(JoinStatus.Waiting)
+                )
+                .fetch();
+        return fetch;
+    }
+
+}

--- a/src/main/java/com/example/swip/repository/UserStudyRepositoryCustom.java
+++ b/src/main/java/com/example/swip/repository/UserStudyRepositoryCustom.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface UserStudyRepositoryCustom {
     List<Tuple> findAllUsersByStudyId(Long studyId);
+
+    Long findOwnerByStudyId(Long studyId);
 }

--- a/src/main/java/com/example/swip/repository/UserStudyRepositoryImpl.java
+++ b/src/main/java/com/example/swip/repository/UserStudyRepositoryImpl.java
@@ -27,4 +27,16 @@ public class UserStudyRepositoryImpl implements UserStudyRepositoryCustom {
 
         return findAllUsers;
     }
+
+    @Override
+    public Long findOwnerByStudyId(Long studyId) {
+        return queryFactory
+                .select(userStudy.id.userId)
+                .from(userStudy)
+                .where(
+                        userStudy.id.studyId.eq(studyId),
+                        userStudy.is_owner.eq(true)
+                )
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/example/swip/service/JoinRequestService.java
+++ b/src/main/java/com/example/swip/service/JoinRequestService.java
@@ -6,11 +6,14 @@ import com.example.swip.entity.User;
 import com.example.swip.entity.compositeKey.JoinRequestId;
 import com.example.swip.entity.enumtype.JoinStatus;
 import com.example.swip.repository.JoinRequestRepository;
+import com.example.swip.repository.StudyRepository;
+import com.example.swip.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,13 +21,17 @@ import java.time.LocalDateTime;
 public class JoinRequestService {
 
     private final JoinRequestRepository joinRequestRepository;
+    private final UserStudyService userStudyService;
+    private final UserRepository userRepository;
+    private final StudyRepository studyRepository;
 
 
     public boolean getAlreadyRequest(Long userId, Long studyId) {
         return joinRequestRepository.existsById(new JoinRequestId(userId, studyId));
     }
 
-    public JoinRequestId saveJoinRequest(User user, Study study) {
+    @Transactional
+    public void saveJoinRequest(User user, Study study) {
         JoinRequest savedJoinRequest = joinRequestRepository.save(
                 JoinRequest.builder()
                         .id(new JoinRequestId(user.getId(), study.getId()))
@@ -34,7 +41,40 @@ public class JoinRequestService {
                         .join_status(JoinStatus.Waiting) //대기중
                         .build()
         );
+    }
 
-        return savedJoinRequest.getId();
+    public List<JoinRequest> getAllByStudyId(Long studyId) {
+        return joinRequestRepository.findAllByStudyId(studyId);
+    }
+
+    public Integer getAllWaitingCountByStudyId(Long studyId) {
+        List<JoinRequest> allWaitingByStudyId = joinRequestRepository.findAllWaitingByStudyId(studyId);
+        return allWaitingByStudyId.size();
+    }
+
+    @Transactional
+    public void acceptJoinRequest(Long studyId, Long userId) {
+        //join_status update
+        JoinRequest findRequest = joinRequestRepository.findById(new JoinRequestId(userId, studyId)).orElse(null);
+        if (findRequest != null) {
+            findRequest.updateJoinStatus(JoinStatus.Approved);
+        }
+
+        //user_study에 추가
+        User findUser = userRepository.findById(userId).orElse(null);
+        Study findStudy = studyRepository.findById(studyId).orElse(null);
+
+        if(findUser != null && findStudy != null) {
+            userStudyService.saveUserStudy(findUser, findStudy, false);
+        }
+    }
+
+    @Transactional
+    public void rejectJoinRequest(Long studyId, Long userId) {
+        //join_status update
+        JoinRequest findRequest = joinRequestRepository.findById(new JoinRequestId(userId, studyId)).orElse(null);
+        if (findRequest != null) {
+            findRequest.updateJoinStatus(JoinStatus.Rejected);
+        }
     }
 }

--- a/src/main/java/com/example/swip/service/UserStudyService.java
+++ b/src/main/java/com/example/swip/service/UserStudyService.java
@@ -23,11 +23,11 @@ public class UserStudyService {
 
     //저장
     @Transactional
-    public void saveUserStudy(User writer, Study savedStudy, boolean is_owner){
+    public void saveUserStudy(User user, Study savedStudy, boolean is_owner){
 
         UserStudy userStudy = UserStudy.builder()
-                .id(new UserStudyId(writer.getId(), savedStudy.getId()))
-                .user(writer)
+                .id(new UserStudyId(user.getId(), savedStudy.getId()))
+                .user(user)
                 .study(savedStudy)
                 .is_owner(is_owner)
                 .exit_status(ExitStatus.None)
@@ -42,5 +42,9 @@ public class UserStudyService {
     public List<Tuple> getAllUsersByStudyId(Long studyId){
         List<Tuple> allUsersByStudyId = userStudyRepository.findAllUsersByStudyId(studyId);
         return allUsersByStudyId;
+    }
+
+    public Long getOwnerbyStudyId(Long studyId) {
+        return userStudyRepository.findOwnerByStudyId(studyId);
     }
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

스터디 참여 승인 관리 API 구현

## 🧑‍💻 PR 세부 내용

- 스터디별 참여 신청 리스트 조회 API
- 스터디별 참여 신청 인원수 조회 API
- 스터디 참여 승인 API
- 스터디 참여 거부 API

## 📸 스크린샷

![image](https://github.com/SWYP-LUCKY-SEVEN/back-end/assets/58907538/099f8cba-61fd-4bc5-9663-63948c760765)

