### PR TITLE
feat: 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/example/swip/api/AuthApiController.java
+++ b/src/main/java/com/example/swip/api/AuthApiController.java
@@ -1,6 +1,7 @@
 package com.example.swip.api;
 
 import com.example.swip.config.UserPrincipal;
+import com.example.swip.dto.DefaultResponse;
 import com.example.swip.dto.auth.GetNicknameDupleResponse;
 import com.example.swip.dto.auth.GetUserIDResponse;
 import com.example.swip.dto.auth.ValidateTokenResponse;
@@ -32,13 +33,6 @@ public class AuthApiController {
         return ResponseEntity.status(403).build();
     }
 
-    @Operation(summary = "회원 탈퇴", description = "JWT 토큰 해당하는 계정을 지웁니다.")
-    @DeleteMapping("/auth/user_id") // user id 반환
-    public String deleteUserById(@AuthenticationPrincipal UserPrincipal principal){  // Authorization 내 principal 없으면 null 값
-        if(principal != null)
-            return authService.deleteUser(principal.getUserId());
-        return "need JWT in Authorization";
-    }
 
     @Operation(summary = "JWT 검증 with HTTP header", description = "JWT가 userID와 일치하는지 확인합니다. JWT는 헤더 내 Authorization:Bearer ~ 형태의 입력이 필요로 합니다.")
     @GetMapping("/auth/validate/token")

--- a/src/main/java/com/example/swip/api/OauthApiController.java
+++ b/src/main/java/com/example/swip/api/OauthApiController.java
@@ -28,8 +28,14 @@ public class OauthApiController {
             KakaoRegisterDto kakaoRegisterDto = kakaoOauthService.getKakaoProfile(accessToken);
             //회원가입 후, user 정보를 반환함. 회원가입이 되어있다면 바로 user정보를 반환함
             User user = authService.kakaoRegisterUser(kakaoRegisterDto);
-            return ResponseEntity.status(201).body(authService.oauthLogin(user));
+
+            if(user == null)
+                return ResponseEntity.status(403).build();
+
+            OauthKakaoResponse response = authService.oauthLogin(user);
+
+            return ResponseEntity.status(201).body(response);
         }
-        return  ResponseEntity.status(400).build();
+        return  ResponseEntity.status(404).build();
     }
 }

--- a/src/main/java/com/example/swip/api/TesterApiController.java
+++ b/src/main/java/com/example/swip/api/TesterApiController.java
@@ -4,6 +4,7 @@ import com.example.swip.config.UserPrincipal;
 import com.example.swip.dto.DefaultResponse;
 import com.example.swip.service.AuthService;
 import com.example.swip.service.StudyService;
+import com.example.swip.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TesterApiController {
     private final AuthService authService;
+    private final UserService userService;
     private final StudyService studyService;
 
     @Operation(summary = "모든 USER ID 확인 (테스트용 API)", description = "가입된 모든 user의 Id를 반환합니다.")
@@ -28,12 +30,20 @@ public class TesterApiController {
         return ResponseEntity.status(403).build();
     }
 
+    @Operation(summary = "회원 탈퇴 JWT (테스트용 API)", description = "JWT 토큰 해당하는 계정을 지웁니다.")
+    @DeleteMapping("/auth/user_id") // user id 반환
+    public String deleteUserById(@AuthenticationPrincipal UserPrincipal principal){  // Authorization 내 principal 없으면 null 값
+        if(principal != null)
+            return userService.deleteUser(principal.getUserId());
+        return "need JWT in Authorization";
+    }
+
     @Operation(summary = "회원 탈퇴 (테스트용 API)", description = "입력된 ID의 계정을 지웁니다.")
     @DeleteMapping("/auth/{user_id}") // user id 반환
     public String deleteUserByUserId(
             @PathVariable("user_id") Long user_id
     ){  // Authorization 내 principal 없으면 null 값
-        return authService.deleteUser(user_id);
+        return userService.deleteUser(user_id);
     }
 
     @Operation(summary = "특정 유저 스터디 참가 (테스트용 API)",

--- a/src/main/java/com/example/swip/api/UserApiController.java
+++ b/src/main/java/com/example/swip/api/UserApiController.java
@@ -1,6 +1,7 @@
 package com.example.swip.api;
 
 import com.example.swip.config.UserPrincipal;
+import com.example.swip.dto.DefaultResponse;
 import com.example.swip.dto.UserMainProfileDto;
 import com.example.swip.dto.UserProfileGetResponse;
 import com.example.swip.dto.UserRelatedStudyCount;
@@ -76,6 +77,15 @@ public class UserApiController {
                         .build()
         );
     }
+    @Operation(summary = "닉네임 중복 확인", description = "path param으로 입력된 nickname의 존재 여부를 반환함.")
+    @GetMapping("/user/nickname/{nickname}") //
+    public ResponseEntity<GetNicknameDupleResponse> NicknameDuplicateCheck(
+            @PathVariable("nickname") String nickname
+    ) {
+        return ResponseEntity.status(200).body(GetNicknameDupleResponse.builder()
+                .isDuplicate(userService.isDuplicatedNickname(nickname))
+                .build());
+    }
 
     @Operation(summary = "회원가입 시 프로필 생성 메소드", description = "회원가입 시 프로필을 생성하는 메소드입니다. 헤더 내 Authorization:Bearer ~ 형태의 JWT 토큰을 필요로 합니다. " +
             "우선 회원정보 변경시에도 해당 API를 사용 가능합니다. 회원 정보 변경은 Chat 서버의 고려사항을 파악 후 완성하려 합니다.")
@@ -83,7 +93,7 @@ public class UserApiController {
     public ResponseEntity<PostProfileResponse> postUserProfile(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @Validated PostProfileRequest postProfileRequest
-            ) {
+    ) {
         if(principal == null)
             return ResponseEntity.status(403).build();
 
@@ -97,13 +107,18 @@ public class UserApiController {
         return ResponseEntity.status(201).body(postProfileResponse);
     }
 
-    @Operation(summary = "닉네임 중복 확인", description = "path param으로 입력된 nickname의 존재 여부를 반환함.")
-    @GetMapping("/user/nickname/{nickname}") //
-    public ResponseEntity<GetNicknameDupleResponse> NicknameDuplicateCheck(
-            @PathVariable("nickname") String nickname
-    ) {
-        return ResponseEntity.status(200).body(GetNicknameDupleResponse.builder()
-                .isDuplicate(userService.isDuplicatedNickname(nickname))
-                .build());
+
+    @Operation(summary = "회원 탈퇴", description = "JWT 토큰 해당하는 계정에 탈퇴 과정을 진행합니다.")
+    @PatchMapping("/user/withdrawal") //
+    public ResponseEntity<DefaultResponse> withdrawalUser(@AuthenticationPrincipal UserPrincipal principal) {
+        if(principal == null)
+            return null;
+        Long userId = userService.withdrawal(principal.getUserId());
+        if(userId==null)
+            return ResponseEntity.status(404).build();
+
+        return ResponseEntity.status(200).body(
+                chatServerService.deleteUser(userId)
+        );
     }
 }

--- a/src/main/java/com/example/swip/config/DailyCleanupTask.java
+++ b/src/main/java/com/example/swip/config/DailyCleanupTask.java
@@ -1,0 +1,21 @@
+package com.example.swip.config;
+
+import com.example.swip.service.UserService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class DailyCleanupTask {
+    private final UserService userService;
+
+    public DailyCleanupTask(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void cleanupActive() {
+        userService.deleteExpiredUserData(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/swip/entity/Study.java
+++ b/src/main/java/com/example/swip/entity/Study.java
@@ -66,8 +66,11 @@ public class Study {
     @Builder.Default
     private List<UserStudy> userStudies = new ArrayList<>();
 
+    @OneToMany(mappedBy = "study")
+    @Builder.Default
+    private List<FavoriteStudy> favoriteStudies = new ArrayList<>();
+
     public void updateCurParticipants(){
         this.cur_participants_num = this.cur_participants_num + 1;
     }
-
 }

--- a/src/main/java/com/example/swip/entity/User.java
+++ b/src/main/java/com/example/swip/entity/User.java
@@ -44,14 +44,17 @@ public class User {
     @Builder.Default
     private List<Evaluation> evaluations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<UserStudy> userStudies = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<FavoriteStudy> favoriteStudies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<JoinRequest> joinRequests = new ArrayList<>();
-
     //기존 error 때문에 넣어둔 field => 추후 삭제 요망 (현재는 테스트 코드 용으로 사용중)
     private String password;
 }

--- a/src/main/java/com/example/swip/repository/UserRepository.java
+++ b/src/main/java/com/example/swip/repository/UserRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long>{
     User findByEmail(String email);
+    User findByEmailAndValidate(String email, String validate);
     User findByNickname(String nickname);
 }

--- a/src/main/java/com/example/swip/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/example/swip/repository/UserRepositoryCustom.java
@@ -10,6 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import static com.example.swip.entity.QUserStudy.userStudy;
 import static com.example.swip.entity.QFavoriteStudy.favoriteStudy;
@@ -73,5 +74,10 @@ public class UserRepositoryCustom {
                 .fetchOne();
         System.out.println(test);
         return test;
+    }
+
+    public void deleteExpiredUserData(LocalDateTime time) {
+        QUser user = QUser.user;
+        queryFactory.delete(user).where(user.withdrawal_date.before(time));
     }
 }

--- a/src/main/java/com/example/swip/service/AuthService.java
+++ b/src/main/java/com/example/swip/service/AuthService.java
@@ -14,7 +14,6 @@ public interface AuthService {
     public OauthKakaoResponse oauthLogin(User user);
 
     public String addUser(String email, String password);
-    public String deleteUser(Long id);
     public User kakaoRegisterUser(KakaoRegisterDto kakaoRegisterDto);
 
     public ValidateTokenResponse compareJWTWithId(String jwt, long user_id);

--- a/src/main/java/com/example/swip/service/ChatServerService.java
+++ b/src/main/java/com/example/swip/service/ChatServerService.java
@@ -1,8 +1,11 @@
 package com.example.swip.service;
 
+import com.example.swip.dto.DefaultResponse;
 import com.example.swip.dto.auth.PostProfileDto;
 import com.example.swip.dto.auth.PostProfileResponse;
 
 public interface ChatServerService {
     PostProfileResponse postUser(PostProfileDto postProfileDto);
+    PostProfileResponse updateUser(PostProfileDto postProfileDto);
+    DefaultResponse deleteUser(Long userId);
 }

--- a/src/main/java/com/example/swip/service/UserService.java
+++ b/src/main/java/com/example/swip/service/UserService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -89,5 +90,33 @@ public class UserService {
     public Long saveUser(AddUserRequest addUserRequest){
         User savedUser = userRepository.save(addUserRequest.toEntity());
         return savedUser.getId();
+    }
+
+    @Transactional
+    public Long withdrawal(Long id) {
+        User user = userRepository.findById(id).orElse(null);
+        if(user != null) {
+            String email = user.getEmail();
+            String validate = user.getValidate();
+            userRepository.deleteById(id);
+            User savedUser = userRepository.save(User.builder()
+                            .email(email)
+                            .validate(validate)
+                            .withdrawal_date(LocalDateTime.now().plusDays(30))
+                    .build());
+            return savedUser.getId();
+        }else
+            return null;
+    }
+
+    @Transactional
+    public void deleteExpiredUserData(LocalDateTime time) {
+        userRepositoryCustom.deleteExpiredUserData(time);
+    }
+
+    public String deleteUser(Long id) {
+        if(userRepository.existsById(id))
+            userRepository.deleteById(id);
+        return "SignUp success";
     }
 }

--- a/src/main/java/com/example/swip/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/swip/service/impl/AuthServiceImpl.java
@@ -83,11 +83,6 @@ public class AuthServiceImpl implements AuthService {
         return "SignUp success";
     }
 
-    public String deleteUser(Long id) {
-        if(userRepository.existsById(id))
-            userRepository.deleteById(id);
-        return "SignUp success";
-    }
     public OauthKakaoResponse oauthLogin(User user) {
         System.out.println("test : " + user.getEmail() + ", " + user.getValidate());
 
@@ -109,10 +104,12 @@ public class AuthServiceImpl implements AuthService {
     }
 
     public User kakaoRegisterUser(KakaoRegisterDto kakaoRegisterDto) {
-        User user = userRepository.findByEmail(kakaoRegisterDto.getEmail());
+        User user = userRepository.findByEmailAndValidate(kakaoRegisterDto.getEmail(), "kakao");
         if(user == null) {
             user = userRepository.save(kakaoRegisterDto.toEntity());
         }
+        if(user.getWithdrawal_date() != null)
+            return null;
         return user;
     }
 

--- a/src/main/java/com/example/swip/service/impl/ChatServerServiceImpl.java
+++ b/src/main/java/com/example/swip/service/impl/ChatServerServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.swip.service.impl;
 
+import com.example.swip.dto.DefaultResponse;
 import com.example.swip.dto.auth.PostProfileDto;
 import com.example.swip.dto.auth.PostProfileResponse;
 import com.example.swip.service.ChatServerService;
@@ -12,6 +13,9 @@ import org.springframework.stereotype.Service;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,59 +23,83 @@ public class ChatServerServiceImpl implements ChatServerService {
     @Value("${swyp.chat.server.uri}")
     private String reqURL;
     public PostProfileResponse postUser(PostProfileDto postProfileDto){
+        String jsonInputString = "{\"pk\":\""+postProfileDto.getUser_id().toString()
+                +"\",\"nickname\":\""+postProfileDto.getNickname()
+                +"\",\"pic\":\""+postProfileDto.getProfileImage()+"\"}";
+        String result = sendHttpRequest(reqURL, "POST", jsonInputString);
+
+        return PostProfileResponse.builder()
+                .message(result)
+                .build();
+    }
+
+    public PostProfileResponse updateUser(PostProfileDto postProfileDto){
+        return null;
+    }
+    public DefaultResponse deleteUser(Long userId){
+        sendHttpRequest(reqURL, "POST", "");
+        Map<String, String> queryParams = Map.of("pk", userId.toString());
+        String responseDelete = sendRequestUserQueryParam(reqURL, "DELETE", queryParams);
+        return DefaultResponse.builder()
+                .message(responseDelete)
+                .build();
+    }
+    public static String sendHttpRequest(String reqURL, String method, String jsonInputString) {
+        StringBuilder response = new StringBuilder();
         try {
             URL url = new URL(reqURL);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
-            // POST 요청을 위해 기본값이 false인 setDoOutput을 true로 설정
-            conn.setRequestMethod("POST");
+            // HTTP 메서드 설정
+            conn.setRequestMethod(method);
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setDoOutput(true);
             conn.setConnectTimeout(1000); // 1초
             conn.setReadTimeout(1000);
 
-            String jsonInputString = "{\"pk\":\""+postProfileDto.getUser_id().toString()
-                    +"\",\"nickname\":\""+postProfileDto.getNickname()
-                    +"\",\"pic\":\""+postProfileDto.getProfileImage()+"\"}";
-            // 서버로 전송할 JSON 형식의 문자열을 정의
-
-            System.out.println("jsonInputString : " + jsonInputString);
-            try(OutputStream os = conn.getOutputStream()) {
-                byte[] input = jsonInputString.getBytes("utf-8"); // JSON 문자열을 바이트 배열로 변환
-                os.write(input, 0, input.length); // 변환된 바이트 배열을 출력 스트림을 통해 전송
+            if ("POST".equals(method) || "PUT".equals(method)) {
+                try (OutputStream os = conn.getOutputStream()) {
+                    byte[] input = jsonInputString.getBytes("utf-8"); // JSON 문자열을 바이트 배열로 변환
+                    os.write(input, 0, input.length); // 변환된 바이트 배열을 출력 스트림을 통해 전송
+                }
             }
 
             int responseCode = conn.getResponseCode();
             System.out.println("responseCode : " + responseCode);
 
-            if(responseCode >= 300 || responseCode < 200)
-                return PostProfileResponse.builder()
-                        .message("Registered on http server only. chatting server disconnected.")
-                        .build();
-
-            // 요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
-            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            String line = "";
-            StringBuffer response = new StringBuffer();
-
-            while ((line = br.readLine()) != null) {
-                response.append(line);
+            if (responseCode >= 300 || responseCode < 200) {
+                return "HTTP request failed. Response code: " + responseCode;
             }
-            br.close();
 
+            // 요청을 통해 얻은 Response 메세지 읽어오기
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    response.append(line);
+                }
+            }
             System.out.println("response body : " + response);
-
-            // Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
-            JsonParser parser = new JsonParser();
-            JsonElement element = parser.parse(response.toString());
-
-            // test = element.getAsJsonObject().get("access_token").getAsString();
-
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return PostProfileResponse.builder()
-                .message("regist success!")
-                .build();
+
+        return "success!";
+    }
+    public static String sendRequestUserQueryParam(String reqURL, String method, Map<String, String> queryParams) {
+        String jsonInputString = null; // GET 요청에는 body가 없으므로 null 처리
+        // 쿼리 파라미터 추가
+        if (queryParams != null && !queryParams.isEmpty()) {
+            StringBuilder query = new StringBuilder();
+            for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+                if (query.length() > 0) {
+                    query.append("&");
+                }
+                query.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8));
+                query.append("=");
+                query.append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+            }
+            reqURL += "?" + query.toString();
+        }
+        return sendHttpRequest(reqURL, method, jsonInputString);
     }
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

회원 탈퇴시 30일간 식별 데이터 보존 후 삭제

## 🧑‍💻 PR 세부 내용

회원 탈퇴시 Chat 서버 회원 데이터 삭제,
관련 찜 목록 및 스터디 참여 정보, 스터디 신청 정보 일괄 삭제.
회원 식별 정보만 저장, 해당 정보는 30일 뒤 삭제.
- 스터디 신청에 Casecade 작성함.
### 문제점
스터디 신청 정보 부분 삭제가 원활하지 않음

## 📸 스크린샷

![image](https://github.com/SWYP-LUCKY-SEVEN/back-end/assets/58322578/ca2e9f97-5d7b-41aa-a2e2-763e9f882fa9)

