### PR TITLE
fix: 스터디 중복 가입 & max 인원 초과 수정

### DIFF
--- a/src/main/java/com/example/swip/entity/Study.java
+++ b/src/main/java/com/example/swip/entity/Study.java
@@ -82,9 +82,9 @@ public class Study {
     private List<StudyTodo> studyTodos = new ArrayList<>();
 
     public void updateCurParticipants(String sign, int num){
-        if(Objects.equals(sign, "+")){
+        if(Objects.equals(sign, "+") && this.cur_participants_num < this.max_participants_num){
             this.cur_participants_num = this.cur_participants_num + num;
-        } else if (Objects.equals(sign, "-")) {
+        } else if (Objects.equals(sign, "-") && this.cur_participants_num > 0) {
             this.cur_participants_num = this.cur_participants_num - num;
         }
 

--- a/src/main/java/com/example/swip/repository/JoinRequestRepository.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepository.java
@@ -2,6 +2,7 @@ package com.example.swip.repository;
 
 import com.example.swip.entity.JoinRequest;
 import com.example.swip.entity.compositeKey.JoinRequestId;
+import com.example.swip.entity.enumtype.JoinStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JoinRequestRepository extends JpaRepository<JoinRequest, JoinRequestId>, JoinRequestRepositoryCustom {

--- a/src/main/java/com/example/swip/repository/JoinRequestRepositoryCustom.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.example.swip.repository;
 
 import com.example.swip.entity.JoinRequest;
+import com.example.swip.entity.compositeKey.JoinRequestId;
+import com.example.swip.entity.enumtype.JoinStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,4 +13,6 @@ public interface JoinRequestRepositoryCustom {
     List<JoinRequest> findAllWaitingByStudyId(Long studyId);
 
     void deleteExpiredJoinRequest(LocalDateTime time);
+
+    JoinStatus findJoinStatusById(JoinRequestId joinRequestId);
 }

--- a/src/main/java/com/example/swip/repository/JoinRequestRepositoryImpl.java
+++ b/src/main/java/com/example/swip/repository/JoinRequestRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.swip.repository;
 
 import com.example.swip.entity.JoinRequest;
+import com.example.swip.entity.compositeKey.JoinRequestId;
 import com.example.swip.entity.enumtype.JoinStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -51,6 +52,15 @@ public class JoinRequestRepositoryImpl implements JoinRequestRepositoryCustom{
                 .delete(joinRequest)
                 .where(joinRequest.request_date.before(time.minusDays(2)))
                 .execute();
+    }
+
+    @Override
+    public JoinStatus findJoinStatusById(JoinRequestId joinRequestId) {
+        return queryFactory
+                .select(joinRequest.join_status)
+                .from(joinRequest)
+                .where(joinRequest.id.eq(joinRequestId))
+                .fetchOne();
     }
 
 }

--- a/src/main/java/com/example/swip/service/JoinRequestService.java
+++ b/src/main/java/com/example/swip/service/JoinRequestService.java
@@ -116,4 +116,8 @@ public class JoinRequestService {
     public void deleteExpiredJoinRequest(LocalDateTime time){
         joinRequestRepository.deleteExpiredJoinRequest(time);
     }
+
+    public JoinStatus checkJoinStatusById(Long studyId, Long userId) {
+        return joinRequestRepository.findJoinStatusById(new JoinRequestId(userId, studyId));
+    }
 }

--- a/src/main/java/com/example/swip/service/StudyService.java
+++ b/src/main/java/com/example/swip/service/StudyService.java
@@ -353,6 +353,17 @@ public class StudyService {
         }
         return false;
     }
+
+    public boolean isAlreadyFull(Long studyId) {
+        Study findStudy = studyRepository.findById(studyId).orElse(null);
+        int curNum = findStudy.getCur_participants_num();
+        int maxNum = findStudy.getMax_participants_num();
+        if(curNum==maxNum){
+            return true;
+        }else{
+            return false;
+        }
+    }
 }
 
 

--- a/src/main/java/com/example/swip/service/UserStudyService.java
+++ b/src/main/java/com/example/swip/service/UserStudyService.java
@@ -99,4 +99,5 @@ public class UserStudyService {
                     });
         }
     }
+
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

스터디 가입 승인/거부 API 수정

## 🧑‍💻 PR 세부 내용

스터디 중복 가입 & max 인원 초과 수정
- 같은 유저가 한 스터디에 중복해서 승인되거나 거부되지 못하도록 수정.
- 승인된 유저 -> 재승인/거부 불가 (202: "이미 수락된 사용자입니다")
- 거부된 유저 -> 승인/재거부 불가 (202: "이미 거부된 사용자입니다")
- 방장이 승인을 하는 시점에 해당 스터디의 인원이 이미 꽉 찬 상태이면, 인원 초과로 승인 불가. (202: "참여 인원이 꽉 찼습니다.") 

## 📸 스크린샷

x
