### PR TITLE
fix : my study 리스트 조회 기능 수정 및 cron 자동 실행 오류 수정

### DIFF
--- a/src/main/java/com/example/swip/SwipApplication.java
+++ b/src/main/java/com/example/swip/SwipApplication.java
@@ -4,11 +4,13 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.TimeZone;
 
+@EnableScheduling
 @SpringBootApplication
 public class SwipApplication {
 

--- a/src/main/java/com/example/swip/api/UserApiController.java
+++ b/src/main/java/com/example/swip/api/UserApiController.java
@@ -166,7 +166,7 @@ public class UserApiController {
     }
 
 
-    @Operation(summary = "내 스터디 신청 목록 확인(참가 신청 & 시작 전)",
+    @Operation(summary = "내 스터디 신청 목록 확인(참가 신청)",
             description = "내 스터디 신청 목록 확인")
     @GetMapping("/user/proposer/study")
     public ResponseEntity getProposerStudy(
@@ -209,6 +209,8 @@ public class UserApiController {
     @Operation(summary = "참가 스터디 목록 확인",
             description = "status (null 허용): before, progress, done.\n" +
                     "- null일 경우: 진행 중이며, 참여 중인 스터디 출력.\n" +
+                    "- before : 진행 전, 참여 중인 스터디 출력.\n" +
+                    "- progress : 진행 중, 참여 중인 스터디 출력"+
                     "- done : 완료한 스터디 출력")
     @GetMapping("/user/registered/study")
     public ResponseEntity getRegisteredStudy(

--- a/src/main/java/com/example/swip/config/DailyCleanupTask.java
+++ b/src/main/java/com/example/swip/config/DailyCleanupTask.java
@@ -20,7 +20,8 @@ public class DailyCleanupTask {
     private final JoinRequestService joinRequestService;
 
 
-    @Scheduled(cron = "0 0 0 * * *")
+    //@Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(fixedRate = 5000)
     public void cleanupActive() {
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/example/swip/service/StudyService.java
+++ b/src/main/java/com/example/swip/service/StudyService.java
@@ -256,10 +256,6 @@ public class StudyService {
         List<StudyFilterResponse> list =
                 studyListToStudyFilterResponse(userService.getProposerStudyList(userId));
 
-        List<StudyFilterResponse> responses = userService.getRegisteredStudyList(userId,
-                        StudyProgressStatus.Element.BeforeStart);
-
-        list.addAll(responses);
         list.sort(Comparator.comparing(StudyFilterResponse::getCreated_time));
         return list;
     }

--- a/src/main/java/com/example/swip/service/impl/KakaoOauthServiceImpl.java
+++ b/src/main/java/com/example/swip/service/impl/KakaoOauthServiceImpl.java
@@ -148,6 +148,9 @@ public class KakaoOauthServiceImpl implements KakaoOauthService {
         String email = "";
         String nickname = "";
         //JAVA HTTP POST 작성
+        if(adminKey == null){
+            throw new IllegalArgumentException("The admin key cannot be null");
+        }
         try {
             URL url = new URL("https://kapi.kakao.com/v1/user/logout");
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

my study 리스트 조회 API 수정 및 오류 수정

## 🧑‍💻 PR 세부 내용

/user/proposer/study : 참가 신청 내역만 조회
/user/registered/study: 참가 스터디 목록 확인
 -> status 로 대기/참여중/완료 나눠서 조회 (대기: before, 참여중: progress, 완료: done)
 -> 대기(status = before)의 경우 is_owner : true 일 경우 취소 버튼이 안 나오도록 구현 필요.

## 📸 스크린샷

-
